### PR TITLE
feat(multimodal): Add Multimodal Chain-of-Thought Reasoning paper fro…

### DIFF
--- a/amazon-multimodal-cot.md
+++ b/amazon-multimodal-cot.md
@@ -1,0 +1,41 @@
+# Multimodal Chain-of-Thought Reasoning in Language Models
+
+**Authors**: Amazon Science Team  
+**Link**: [arXiv](https://arxiv.org/abs/2302.00923)  
+**Code**: [GitHub](https://github.com/amazon-science/mm-cot)  
+**Year**: 2023
+
+## Summary
+Novel approach that extends chain-of-thought reasoning to multimodal (vision + language) tasks through a two-stage framework that separates rationale generation from answer inference. Achieves SOTA on ScienceQA benchmark using a sub-1B parameter model while reducing hallucination and improving convergence speed.
+
+## Key Innovations
+- Two-stage architecture separating rationale generation and answer inference
+- Multimodal information integration for enhanced reasoning
+- Sub-1B parameter efficient design
+- Reduced hallucination in reasoning chains
+- Faster training convergence
+
+## Why It Matters for A2A
+1. Provides architectural blueprint for multimodal reasoning systems
+2. Demonstrates effective parameter-efficient design
+3. Shows path to more reliable multimodal interactions
+4. Enables transparent reasoning processes
+
+## Technical Implementation
+```python
+class MultimodalCoT:
+    def __init__(self):
+        self.vision_encoder = VisionEncoder() 
+        self.text_encoder = TextEncoder()
+        self.rationale_generator = RationaleGenerator()
+        self.answer_inferrer = AnswerInferrer()
+
+    def forward(self, image, question):
+        # Stage 1: Rationale Generation
+        visual_features = self.vision_encoder(image)
+        text_features = self.text_encoder(question)
+        rationale = self.rationale_generator(visual_features, text_features)
+        
+        # Stage 2: Answer Inference
+        answer = self.answer_inferrer(rationale, visual_features, text_features)
+        return answer, rationale


### PR DESCRIPTION
…m Amazon Science

Add paper analysis for "Multimodal Chain-of-Thought Reasoning in Language Models"

- Introduces novel two-stage multimodal CoT framework
- Achieves SOTA on ScienceQA with sub-1B parameter model
- Provides implementation for multimodal reasoning
- Demonstrates reduced hallucination and faster convergence
- Includes code examples and key insights